### PR TITLE
Refactor/18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,12 @@ dependencies {
 
     // BCrypt
     implementation 'org.mindrot:jbcrypt:0.4'
+
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
@@ -99,8 +105,23 @@ jacocoTestReport {
         xml.required = true
         html.required = true
     }
+
+    def Qdomains = []
+    for (qPattern in "**/QA".."**/QZ") {
+        Qdomains.add(qPattern + "*")
+    }
+
+    afterEvaluate {
+
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: [] + Qdomains)
+        }))
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
 }
 
 jar {
-	enabled = false
+    enabled = false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ jacocoTestReport {
 
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it,
-                    exclude: [] + Qdomains)
+                    exclude: ['**/*Builder.*'] + Qdomains)
         }))
     }
 

--- a/src/main/java/site/courseregistrationsystem/auth/StudentSession.java
+++ b/src/main/java/site/courseregistrationsystem/auth/StudentSession.java
@@ -5,13 +5,12 @@ import org.springframework.data.redis.core.TimeToLive;
 
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @RedisHash("session")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 public class StudentSession {
 
@@ -22,5 +21,12 @@ public class StudentSession {
 
 	@TimeToLive
 	private Long expiration;
+
+	@Builder
+	private StudentSession(String id, Long studentPk, Long expiration) {
+		this.id = id;
+		this.studentPk = studentPk;
+		this.expiration = expiration;
+	}
 
 }

--- a/src/main/java/site/courseregistrationsystem/auth/application/SessionManager.java
+++ b/src/main/java/site/courseregistrationsystem/auth/application/SessionManager.java
@@ -19,7 +19,11 @@ public class SessionManager {
 
 	public StudentSession generate(Long studentPk) {  // 세션 생성 및 저장
 		String sessionId = UUID.randomUUID().toString();
-		StudentSession session = new StudentSession(sessionId, studentPk, SESSION_EXPIRY);
+		StudentSession session = StudentSession.builder()
+			.id(sessionId)
+			.studentPk(studentPk)
+			.expiration(SESSION_EXPIRY)
+			.build();
 
 		return sessionStorage.save(session);
 	}

--- a/src/main/java/site/courseregistrationsystem/auth/dto/LoginForm.java
+++ b/src/main/java/site/courseregistrationsystem/auth/dto/LoginForm.java
@@ -1,13 +1,12 @@
 package site.courseregistrationsystem.auth.dto;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.courseregistrationsystem.validator.PasswordFormatCheck;
 import site.courseregistrationsystem.validator.StudentIdFormatCheck;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 public class LoginForm {
 
@@ -16,5 +15,11 @@ public class LoginForm {
 
 	@PasswordFormatCheck
 	private String password;
+
+	@Builder
+	private LoginForm(String studentId, String password) {
+		this.studentId = studentId;
+		this.password = password;
+	}
 
 }

--- a/src/main/java/site/courseregistrationsystem/config/JpaConfig.java
+++ b/src/main/java/site/courseregistrationsystem/config/JpaConfig.java
@@ -1,0 +1,18 @@
+package site.courseregistrationsystem.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class JpaConfig {
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+		return new JPAQueryFactory(entityManager);
+	}
+
+}

--- a/src/main/java/site/courseregistrationsystem/department/infrastructure/DepartmentRepository.java
+++ b/src/main/java/site/courseregistrationsystem/department/infrastructure/DepartmentRepository.java
@@ -1,9 +1,0 @@
-package site.courseregistrationsystem.department.infrastructure;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import site.courseregistrationsystem.department.Department;
-
-public interface DepartmentRepository extends JpaRepository<Department, Long> {
-
-}

--- a/src/main/java/site/courseregistrationsystem/lecture/Lecture.java
+++ b/src/main/java/site/courseregistrationsystem/lecture/Lecture.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.courseregistrationsystem.professor.Professor;
@@ -40,7 +41,8 @@ public class Lecture {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Professor professor;
 
-	public Lecture(Integer lectureNumber, String lectureRoom, Integer totalCapacity, Subject subject,
+	@Builder
+	private Lecture(Integer lectureNumber, String lectureRoom, Integer totalCapacity, Subject subject,
 		Professor professor) {
 		this.lectureNumber = lectureNumber;
 		this.lectureRoom = lectureRoom;

--- a/src/main/java/site/courseregistrationsystem/lecture/dto/LectureFilterOptions.java
+++ b/src/main/java/site/courseregistrationsystem/lecture/dto/LectureFilterOptions.java
@@ -1,15 +1,23 @@
 package site.courseregistrationsystem.lecture.dto;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import site.courseregistrationsystem.subject.SubjectDivision;
 
-@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class LectureFilterOptions {
 
 	private SubjectDivision subjectDivision;
 	private Long departmentId;
 	private String subjectName;
+
+	@Builder
+	private LectureFilterOptions(SubjectDivision subjectDivision, Long departmentId, String subjectName) {
+		this.subjectDivision = subjectDivision;
+		this.departmentId = departmentId;
+		this.subjectName = subjectName;
+	}
 
 }

--- a/src/main/java/site/courseregistrationsystem/lecture/infrastructure/LectureRepository.java
+++ b/src/main/java/site/courseregistrationsystem/lecture/infrastructure/LectureRepository.java
@@ -1,25 +1,9 @@
 package site.courseregistrationsystem.lecture.infrastructure;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import site.courseregistrationsystem.lecture.Lecture;
-import site.courseregistrationsystem.subject.SubjectDivision;
 
-public interface LectureRepository extends JpaRepository<Lecture, Long> {
-
-	@Query(value =
-		"SELECT l FROM Lecture l "
-			+ "JOIN FETCH l.subject s "
-			+ "JOIN FETCH s.department d "
-			+ "JOIN FETCH l.professor "
-			+ "WHERE (:subjectDivision IS NULL OR s.subjectDivision = :subjectDivision) "
-			+ "AND (:departmentId IS NULL OR d.id = :departmentId) "
-			+ "AND (:subjectName IS NULL OR s.name LIKE %:subjectName%) "
-	)
-	Page<Lecture> findMatchedLectures(Pageable pageable, SubjectDivision subjectDivision, Long departmentId,
-		String subjectName);
+public interface LectureRepository extends JpaRepository<Lecture, Long>, LectureRepositoryCustom {
 
 }

--- a/src/main/java/site/courseregistrationsystem/lecture/infrastructure/LectureRepositoryCustom.java
+++ b/src/main/java/site/courseregistrationsystem/lecture/infrastructure/LectureRepositoryCustom.java
@@ -1,0 +1,13 @@
+package site.courseregistrationsystem.lecture.infrastructure;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import site.courseregistrationsystem.lecture.Lecture;
+import site.courseregistrationsystem.subject.SubjectDivision;
+
+public interface LectureRepositoryCustom {
+
+	Page<Lecture> findMatchedLectures(Pageable pageable, SubjectDivision subjectDivision, Long departmentId, String subjectName);
+
+}

--- a/src/main/java/site/courseregistrationsystem/lecture/infrastructure/LectureRepositoryImpl.java
+++ b/src/main/java/site/courseregistrationsystem/lecture/infrastructure/LectureRepositoryImpl.java
@@ -1,0 +1,80 @@
+package site.courseregistrationsystem.lecture.infrastructure;
+
+import static site.courseregistrationsystem.department.QDepartment.*;
+import static site.courseregistrationsystem.lecture.QLecture.*;
+import static site.courseregistrationsystem.professor.QProfessor.*;
+import static site.courseregistrationsystem.subject.QSubject.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import site.courseregistrationsystem.lecture.Lecture;
+import site.courseregistrationsystem.subject.SubjectDivision;
+
+@RequiredArgsConstructor
+public class LectureRepositoryImpl implements LectureRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<Lecture> findMatchedLectures(Pageable pageable, SubjectDivision subjectDivision, Long departmentId, String subjectName) {
+		List<Lecture> lectures = queryFactory.selectFrom(lecture)
+			.join(lecture.subject, subject).fetchJoin()
+			.join(lecture.subject.department, department).fetchJoin()
+			.join(lecture.professor, professor).fetchJoin()
+			.where(
+				subjectDivisionEq(subjectDivision),
+				departmentEq(departmentId),
+				subjectNameContains(subjectName)
+			)
+			.orderBy(lecture.id.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		JPAQuery<Long> countQuery = queryFactory
+			.select(lecture.count())
+			.from(lecture)
+			.where(
+				subjectDivisionEq(subjectDivision),
+				departmentEq(departmentId),
+				subjectNameContains(subjectName)
+			);
+
+		return PageableExecutionUtils.getPage(lectures, pageable, countQuery::fetchOne);
+	}
+
+	private BooleanExpression subjectDivisionEq(SubjectDivision subjectDivision) {
+		if (subjectDivision == null) {
+			return null;
+		}
+
+		return lecture.subject.subjectDivision.eq(subjectDivision);
+	}
+
+	private BooleanExpression departmentEq(Long departmentId) {
+		if (departmentId == null) {
+			return null;
+		}
+
+		return lecture.subject.department.id.eq(departmentId);
+	}
+
+	private BooleanExpression subjectNameContains(String subjectName) {
+		if (!StringUtils.hasText(subjectName)) {
+			return null;
+		}
+
+		return lecture.subject.name.contains(subjectName);
+	}
+
+}

--- a/src/main/java/site/courseregistrationsystem/lecture/presentation/LectureController.java
+++ b/src/main/java/site/courseregistrationsystem/lecture/presentation/LectureController.java
@@ -20,7 +20,7 @@ public class LectureController {
 
 	@GetMapping("/lectures")
 	public ApiResponse<LectureSchedulePage> fetchLectureSchedule(
-		@PageableDefault(size = 20, sort = "id") Pageable pageable, LectureFilterOptions lectureFilterOptions) {
+		@PageableDefault(size = 20) Pageable pageable, LectureFilterOptions lectureFilterOptions) {
 		return ApiResponse.ok(ResponseMessage.LECTURE_SCHEDULE_FETCH_SUCCESS.getMessage(),
 			lectureService.fetchLectureSchedule(pageable, lectureFilterOptions));
 	}

--- a/src/main/java/site/courseregistrationsystem/professor/infrastructure/ProfessorRepository.java
+++ b/src/main/java/site/courseregistrationsystem/professor/infrastructure/ProfessorRepository.java
@@ -1,9 +1,0 @@
-package site.courseregistrationsystem.professor.infrastructure;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import site.courseregistrationsystem.professor.Professor;
-
-public interface ProfessorRepository extends JpaRepository<Professor, Long> {
-
-}

--- a/src/main/java/site/courseregistrationsystem/schedule/Schedule.java
+++ b/src/main/java/site/courseregistrationsystem/schedule/Schedule.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.courseregistrationsystem.lecture.Lecture;
@@ -34,7 +35,8 @@ public class Schedule {
 	@Enumerated(EnumType.STRING)
 	private Period lastPeriod;
 
-	public Schedule(Lecture lecture, DayOfWeek dayOfWeek, Period firstPeriod, Period lastPeriod) {
+	@Builder
+	private Schedule(Lecture lecture, DayOfWeek dayOfWeek, Period firstPeriod, Period lastPeriod) {
 		this.lecture = lecture;
 		this.dayOfWeek = dayOfWeek;
 		this.firstPeriod = firstPeriod;

--- a/src/main/java/site/courseregistrationsystem/schedule/infrastructure/ScheduleRepository.java
+++ b/src/main/java/site/courseregistrationsystem/schedule/infrastructure/ScheduleRepository.java
@@ -1,9 +1,0 @@
-package site.courseregistrationsystem.schedule.infrastructure;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import site.courseregistrationsystem.schedule.Schedule;
-
-public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-
-}

--- a/src/main/java/site/courseregistrationsystem/subject/Subject.java
+++ b/src/main/java/site/courseregistrationsystem/subject/Subject.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.courseregistrationsystem.department.Department;
@@ -36,7 +37,8 @@ public class Subject {
 	private Integer hoursPerWeek;
 	private Integer credits;
 
-	public Subject(Department department, SubjectDivision subjectDivision, Grade targetGrade, String name,
+	@Builder
+	private Subject(Department department, SubjectDivision subjectDivision, Grade targetGrade, String name,
 		Integer hoursPerWeek, Integer credits) {
 		this.department = department;
 		this.subjectDivision = subjectDivision;

--- a/src/main/java/site/courseregistrationsystem/subject/infrastructure/SubjectRepository.java
+++ b/src/main/java/site/courseregistrationsystem/subject/infrastructure/SubjectRepository.java
@@ -1,9 +1,0 @@
-package site.courseregistrationsystem.subject.infrastructure;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import site.courseregistrationsystem.subject.Subject;
-
-public interface SubjectRepository extends JpaRepository<Subject, Long> {
-
-}

--- a/src/test/java/site/courseregistrationsystem/RestDocsSupport.java
+++ b/src/test/java/site/courseregistrationsystem/RestDocsSupport.java
@@ -73,7 +73,11 @@ public abstract class RestDocsSupport {
 				String sessionId = invocation.getArgument(0, String.class);
 
 				if (sessionId.length() == 36) {
-					return new StudentSession(sessionId, 1L, 3600L);
+					return StudentSession.builder()
+						.id(sessionId)
+						.studentPk(1L)
+						.expiration(3600L)
+						.build();
 				}
 
 				throw new NonexistenceSessionException();

--- a/src/test/java/site/courseregistrationsystem/auth/application/AuthServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/auth/application/AuthServiceTest.java
@@ -38,7 +38,7 @@ class AuthServiceTest extends IntegrationTestSupport {
 		String password = "test1234!";
 
 		Student saved = saveStudent(studentId, password);
-		LoginForm loginForm = new LoginForm(studentId, password);
+		LoginForm loginForm = createLoginForm(studentId, password);
 
 		// when
 		StudentSession session = authService.login(loginForm);
@@ -59,12 +59,19 @@ class AuthServiceTest extends IntegrationTestSupport {
 		String wrongPassword = "test0123!";
 
 		Student saved = saveStudent(studentId, password);
-		LoginForm loginForm = new LoginForm(studentId, wrongPassword);
+		LoginForm loginForm = createLoginForm(studentId, wrongPassword);
 
 		// when / then
 		assertThatThrownBy(() -> authService.login(loginForm))
 			.isInstanceOf(InvalidPasswordException.class)
 			.hasMessage(ErrorType.INVALID_PASSWORD.getMessage());
+	}
+
+	private static LoginForm createLoginForm(String studentId, String password) {
+		return LoginForm.builder()
+			.studentId(studentId)
+			.password(password)
+			.build();
 	}
 
 	private Student saveStudent(String studentId, String password) {

--- a/src/test/java/site/courseregistrationsystem/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/site/courseregistrationsystem/auth/presentation/AuthControllerTest.java
@@ -29,13 +29,13 @@ class AuthControllerTest extends RestDocsSupport {
 		// given
 		String studentId = "123456789";
 		String password = "test1234!";
-		LoginForm loginForm = new LoginForm(studentId, password);
+		LoginForm loginForm = createLoginForm(studentId, password);
 
 		String uuid = "a8b0a12b-998c-4d9a-a294-e54a95a9b6ba";
 		Long studentPk = 1L;
 		Long expiration = 3600L;
 		given(authService.login(any(LoginForm.class)))
-			.willReturn(new StudentSession(uuid, studentPk, expiration));
+			.willReturn(createStudentSession(uuid, studentPk, expiration));
 
 		// when & then
 		String cookieName = cookieProperties.getName();
@@ -73,7 +73,7 @@ class AuthControllerTest extends RestDocsSupport {
 		// given
 		String studentId = "012345678";
 		String password = "test1234!";
-		LoginForm loginForm = new LoginForm(studentId, password);
+		LoginForm loginForm = createLoginForm(studentId, password);
 
 		given(authService.login(any(LoginForm.class)))
 			.willThrow(new NonexistenceStudentIdException());
@@ -106,7 +106,7 @@ class AuthControllerTest extends RestDocsSupport {
 		// given
 		String studentId = "123456789";
 		String password = "test0123!";
-		LoginForm loginForm = new LoginForm(studentId, password);
+		LoginForm loginForm = createLoginForm(studentId, password);
 
 		given(authService.login(any(LoginForm.class)))
 			.willThrow(new InvalidPasswordException());
@@ -139,7 +139,7 @@ class AuthControllerTest extends RestDocsSupport {
 		// given
 		String studentId = "12345678";
 		String password = "test1234";
-		LoginForm loginForm = new LoginForm(studentId, password);
+		LoginForm loginForm = createLoginForm(studentId, password);
 
 		// when & then
 		mockMvc.perform(post("/login")
@@ -169,7 +169,7 @@ class AuthControllerTest extends RestDocsSupport {
 	@DisplayName("로그인 : 빈 요청 오류")
 	void loginNull() throws Exception {
 		// given
-		LoginForm loginForm = new LoginForm(null, null);
+		LoginForm loginForm = createLoginForm(null, null);
 
 		// when & then
 		mockMvc.perform(post("/login")
@@ -210,7 +210,7 @@ class AuthControllerTest extends RestDocsSupport {
 		String cookieName = cookieProperties.getName();
 
 		given(sessionManager.renew(anyString()))
-			.willReturn(new StudentSession(RENEW_UUID, STUDENT_PK, EXPIRATION));
+			.willReturn(createStudentSession(RENEW_UUID, STUDENT_PK, EXPIRATION));
 
 		// when & then
 		mockMvc.perform(post("/session")
@@ -286,6 +286,21 @@ class AuthControllerTest extends RestDocsSupport {
 					fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터")
 				)
 			));
+	}
+
+	private static StudentSession createStudentSession(String uuid, Long studentPk, Long expiration) {
+		return StudentSession.builder()
+			.id(uuid)
+			.studentPk(studentPk)
+			.expiration(expiration)
+			.build();
+	}
+
+	private static LoginForm createLoginForm(String studentId, String password) {
+		return LoginForm.builder()
+			.studentId(studentId)
+			.password(password)
+			.build();
 	}
 
 }

--- a/src/test/java/site/courseregistrationsystem/lecture/application/LectureServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/lecture/application/LectureServiceTest.java
@@ -20,7 +20,6 @@ import site.courseregistrationsystem.lecture.dto.LectureFilterOptions;
 import site.courseregistrationsystem.lecture.dto.LectureSchedulePage;
 import site.courseregistrationsystem.lecture.infrastructure.LectureRepository;
 import site.courseregistrationsystem.professor.Professor;
-import site.courseregistrationsystem.professor.infrastructure.ProfessorRepository;
 import site.courseregistrationsystem.schedule.DayOfWeek;
 import site.courseregistrationsystem.schedule.Period;
 import site.courseregistrationsystem.schedule.Schedule;
@@ -47,15 +46,12 @@ class LectureServiceTest extends IntegrationTestSupport {
 	@Autowired
 	private EntityManager entityManager;
 
-	@Autowired
-	private ProfessorRepository professorRepository;
-
 	@Test
 	@DisplayName("검색 조건 없이 강의를 조회한다")
 	void fetch() {
 		// given
 		Department department = saveDepartment("departmentName");
-		Professor professor = professorRepository.save(new Professor("professorName"));
+		Professor professor = saveProfessor("professorName");
 		Subject subject = subjectRepository.save(
 			new Subject(department, SubjectDivision.MR, Grade.FRESHMAN, "subjectName", 3, 2));
 		List<Lecture> lectures = lectureRepository.saveAll(generateCopiedLectureFixtures(50, subject, professor));
@@ -84,7 +80,7 @@ class LectureServiceTest extends IntegrationTestSupport {
 	void fetchWithOptions() {
 		// given
 		Department department = saveDepartment("금속공예디자인학과");
-		Professor professor = professorRepository.save(new Professor("남유진"));
+		Professor professor = saveProfessor("남유진");
 
 		List<Subject> majorRequiredSubjects = subjectRepository.saveAll(
 			generateSubjectFixtures(30, SubjectDivision.MR, department, "공예"));
@@ -173,6 +169,13 @@ class LectureServiceTest extends IntegrationTestSupport {
 		entityManager.persist(department);
 
 		return department;
+	}
+
+	private Professor saveProfessor(String professorName) {
+		Professor professor = new Professor(professorName);
+		entityManager.persist(professor);
+
+		return professor;
 	}
 
 }

--- a/src/test/java/site/courseregistrationsystem/lecture/application/LectureServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/lecture/application/LectureServiceTest.java
@@ -23,7 +23,6 @@ import site.courseregistrationsystem.professor.Professor;
 import site.courseregistrationsystem.schedule.DayOfWeek;
 import site.courseregistrationsystem.schedule.Period;
 import site.courseregistrationsystem.schedule.Schedule;
-import site.courseregistrationsystem.schedule.infrastructure.ScheduleRepository;
 import site.courseregistrationsystem.student.Grade;
 import site.courseregistrationsystem.subject.Subject;
 import site.courseregistrationsystem.subject.SubjectDivision;
@@ -41,9 +40,6 @@ class LectureServiceTest extends IntegrationTestSupport {
 	private SubjectRepository subjectRepository;
 
 	@Autowired
-	private ScheduleRepository scheduleRepository;
-
-	@Autowired
 	private EntityManager entityManager;
 
 	@Test
@@ -55,7 +51,7 @@ class LectureServiceTest extends IntegrationTestSupport {
 		Subject subject = subjectRepository.save(
 			new Subject(department, SubjectDivision.MR, Grade.FRESHMAN, "subjectName", 3, 2));
 		List<Lecture> lectures = lectureRepository.saveAll(generateCopiedLectureFixtures(50, subject, professor));
-		List<Schedule> schedules = scheduleRepository.saveAll(generateScheduleFixtures(lectures));
+		saveSchedules(generateScheduleFixtures(lectures));
 
 		PageRequest pageRequest = PageRequest.of(0, 20, Sort.Direction.ASC, "id");
 		LectureFilterOptions lectureFilterOptions = LectureFilterOptions.builder().build();
@@ -92,8 +88,8 @@ class LectureServiceTest extends IntegrationTestSupport {
 		List<Lecture> unmatchedLectureFixtures = lectureRepository.saveAll(
 			generateLectureFixtures(generalRequiredSubjects, professor));
 
-		scheduleRepository.saveAll(generateScheduleFixtures(matchedLectureFixtures));
-		scheduleRepository.saveAll(generateScheduleFixtures(unmatchedLectureFixtures));
+		saveSchedules(generateScheduleFixtures(matchedLectureFixtures));
+		saveSchedules(generateScheduleFixtures(unmatchedLectureFixtures));
 
 		PageRequest pageRequest = PageRequest.of(0, 20, Sort.Direction.ASC, "id");
 		LectureFilterOptions lectureFilterOptions = LectureFilterOptions.builder()
@@ -176,6 +172,12 @@ class LectureServiceTest extends IntegrationTestSupport {
 		entityManager.persist(professor);
 
 		return professor;
+	}
+
+	private List<Schedule> saveSchedules(List<Schedule> schedules) {
+		schedules.forEach(entityManager::persist);
+
+		return schedules;
 	}
 
 }

--- a/src/test/java/site/courseregistrationsystem/lecture/application/LectureServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/lecture/application/LectureServiceTest.java
@@ -131,7 +131,14 @@ class LectureServiceTest extends IntegrationTestSupport {
 	}
 
 	private List<Schedule> generateScheduleFixtures(List<Lecture> lectures) {
-		return lectures.stream().map(lecture -> new Schedule(lecture, DayOfWeek.MON, Period.SIX, Period.NINE)).toList();
+		return lectures.stream()
+			.map(lecture -> Schedule.builder()
+				.lecture(lecture)
+				.dayOfWeek(DayOfWeek.MON)
+				.firstPeriod(Period.SIX)
+				.lastPeriod(Period.NINE)
+				.build())
+			.toList();
 	}
 
 	private static Lecture createLecture(Integer lectureNumber, String lectureRoom, Integer totalCapacity, Subject subject, Professor professor) {

--- a/src/test/java/site/courseregistrationsystem/lecture/application/LectureServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/lecture/application/LectureServiceTest.java
@@ -12,9 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
+import jakarta.persistence.EntityManager;
 import site.courseregistrationsystem.IntegrationTestSupport;
 import site.courseregistrationsystem.department.Department;
-import site.courseregistrationsystem.department.infrastructure.DepartmentRepository;
 import site.courseregistrationsystem.lecture.Lecture;
 import site.courseregistrationsystem.lecture.dto.LectureFilterOptions;
 import site.courseregistrationsystem.lecture.dto.LectureSchedulePage;
@@ -45,7 +45,7 @@ class LectureServiceTest extends IntegrationTestSupport {
 	private ScheduleRepository scheduleRepository;
 
 	@Autowired
-	private DepartmentRepository departmentRepository;
+	private EntityManager entityManager;
 
 	@Autowired
 	private ProfessorRepository professorRepository;
@@ -54,9 +54,10 @@ class LectureServiceTest extends IntegrationTestSupport {
 	@DisplayName("검색 조건 없이 강의를 조회한다")
 	void fetch() {
 		// given
-		Department department = departmentRepository.save(new Department("departmentName"));
+		Department department = saveDepartment("departmentName");
 		Professor professor = professorRepository.save(new Professor("professorName"));
-		Subject subject = subjectRepository.save(new Subject(department, SubjectDivision.MR, Grade.FRESHMAN, "subjectName", 3, 2));
+		Subject subject = subjectRepository.save(
+			new Subject(department, SubjectDivision.MR, Grade.FRESHMAN, "subjectName", 3, 2));
 		List<Lecture> lectures = lectureRepository.saveAll(generateCopiedLectureFixtures(50, subject, professor));
 		List<Schedule> schedules = scheduleRepository.saveAll(generateScheduleFixtures(lectures));
 
@@ -64,29 +65,36 @@ class LectureServiceTest extends IntegrationTestSupport {
 		LectureFilterOptions lectureFilterOptions = LectureFilterOptions.builder().build();
 
 		// when
-		LectureSchedulePage lectureSchedulePage = lectureService.fetchLectureSchedule(pageRequest, lectureFilterOptions);
+		LectureSchedulePage lectureSchedulePage = lectureService.fetchLectureSchedule(pageRequest,
+			lectureFilterOptions);
 
 		// then
 		int firstIndex = 0;
 
-		assertAll(() -> assertThat(lectureSchedulePage.isFirst()).isTrue(), () -> assertThat(lectureSchedulePage.isLast()).isFalse(),
+		assertAll(() -> assertThat(lectureSchedulePage.isFirst()).isTrue(),
+			() -> assertThat(lectureSchedulePage.isLast()).isFalse(),
 			() -> assertThat(lectureSchedulePage.getTotalElements()).isEqualTo(lectures.size()),
 			() -> assertThat(lectureSchedulePage.getLectures()).hasSize(pageRequest.getPageSize()),
-			() -> assertThat(lectureSchedulePage.getLectures().get(firstIndex).getId()).isEqualTo(lectures.get(firstIndex).getId()));
+			() -> assertThat(lectureSchedulePage.getLectures().get(firstIndex).getId()).isEqualTo(
+				lectures.get(firstIndex).getId()));
 	}
 
 	@Test
 	@DisplayName("금속공예디자인학과의 전공 필수 수업이면서 과목명에 공예가 들어가는 강의를 조회한다")
 	void fetchWithOptions() {
 		// given
-		Department department = departmentRepository.save(new Department("금속공예디자인학과"));
+		Department department = saveDepartment("금속공예디자인학과");
 		Professor professor = professorRepository.save(new Professor("남유진"));
 
-		List<Subject> majorRequiredSubjects = subjectRepository.saveAll(generateSubjectFixtures(30, SubjectDivision.MR, department, "공예"));
-		List<Subject> generalRequiredSubjects = subjectRepository.saveAll(generateSubjectFixtures(10, SubjectDivision.GR, department, "역사"));
+		List<Subject> majorRequiredSubjects = subjectRepository.saveAll(
+			generateSubjectFixtures(30, SubjectDivision.MR, department, "공예"));
+		List<Subject> generalRequiredSubjects = subjectRepository.saveAll(
+			generateSubjectFixtures(10, SubjectDivision.GR, department, "역사"));
 
-		List<Lecture> matchedLectureFixtures = lectureRepository.saveAll(generateLectureFixtures(majorRequiredSubjects, professor));
-		List<Lecture> unmatchedLectureFixtures = lectureRepository.saveAll(generateLectureFixtures(generalRequiredSubjects, professor));
+		List<Lecture> matchedLectureFixtures = lectureRepository.saveAll(
+			generateLectureFixtures(majorRequiredSubjects, professor));
+		List<Lecture> unmatchedLectureFixtures = lectureRepository.saveAll(
+			generateLectureFixtures(generalRequiredSubjects, professor));
 
 		scheduleRepository.saveAll(generateScheduleFixtures(matchedLectureFixtures));
 		scheduleRepository.saveAll(generateScheduleFixtures(unmatchedLectureFixtures));
@@ -99,32 +107,40 @@ class LectureServiceTest extends IntegrationTestSupport {
 			.build();
 
 		// when
-		LectureSchedulePage lectureSchedulePage = lectureService.fetchLectureSchedule(pageRequest, lectureFilterOptions);
+		LectureSchedulePage lectureSchedulePage = lectureService.fetchLectureSchedule(pageRequest,
+			lectureFilterOptions);
 
 		// then
 		int firstIndex = 0;
 
-		assertAll(() -> assertThat(lectureSchedulePage.isFirst()).isTrue(), () -> assertThat(lectureSchedulePage.isLast()).isFalse(),
+		assertAll(() -> assertThat(lectureSchedulePage.isFirst()).isTrue(),
+			() -> assertThat(lectureSchedulePage.isLast()).isFalse(),
 			() -> assertThat(lectureSchedulePage.getTotalElements()).isEqualTo(matchedLectureFixtures.size()),
 			() -> assertThat(lectureSchedulePage.getLectures()).hasSize(pageRequest.getPageSize()),
-			() -> assertThat(lectureSchedulePage.getLectures().get(firstIndex).getId()).isEqualTo(matchedLectureFixtures.get(firstIndex).getId()),
-			() -> assertThat(lectureSchedulePage.getLectures().get(firstIndex).getSubjectDivision()).isEqualTo(SubjectDivision.MR.getDescription()),
-			() -> assertThat(lectureSchedulePage.getLectures().get(firstIndex).getSubjectName()).contains(lectureFilterOptions.getSubjectName()));
+			() -> assertThat(lectureSchedulePage.getLectures().get(firstIndex).getId()).isEqualTo(
+				matchedLectureFixtures.get(firstIndex).getId()),
+			() -> assertThat(lectureSchedulePage.getLectures().get(firstIndex).getSubjectDivision()).isEqualTo(
+				SubjectDivision.MR.getDescription()),
+			() -> assertThat(lectureSchedulePage.getLectures().get(firstIndex).getSubjectName()).contains(
+				lectureFilterOptions.getSubjectName()));
 	}
 
 	private List<Lecture> generateCopiedLectureFixtures(int size, Subject subjects, Professor professor) {
 		return IntStream.rangeClosed(1, size)
-			.mapToObj(number -> createLecture(100100 + number, Integer.toString(100 + number), 10 + number, subjects, professor))
+			.mapToObj(number -> createLecture(100100 + number, Integer.toString(100 + number), 10 + number, subjects,
+				professor))
 			.toList();
 	}
 
 	private List<Lecture> generateLectureFixtures(List<Subject> subjects, Professor professor) {
 		return IntStream.rangeClosed(1, subjects.size())
-			.mapToObj(number -> createLecture(100100 + number, Integer.toString(100 + number), 10 + number, subjects.get(number - 1), professor))
+			.mapToObj(number -> createLecture(100100 + number, Integer.toString(100 + number), 10 + number,
+				subjects.get(number - 1), professor))
 			.toList();
 	}
 
-	private List<Subject> generateSubjectFixtures(int size, SubjectDivision subjectDivision, Department department, String subjectName) {
+	private List<Subject> generateSubjectFixtures(int size, SubjectDivision subjectDivision, Department department,
+		String subjectName) {
 		return IntStream.rangeClosed(1, size)
 			.mapToObj(number -> new Subject(department, subjectDivision, Grade.FRESHMAN, subjectName + number, 4, 3))
 			.toList();
@@ -141,7 +157,8 @@ class LectureServiceTest extends IntegrationTestSupport {
 			.toList();
 	}
 
-	private static Lecture createLecture(Integer lectureNumber, String lectureRoom, Integer totalCapacity, Subject subject, Professor professor) {
+	private static Lecture createLecture(Integer lectureNumber, String lectureRoom, Integer totalCapacity,
+		Subject subject, Professor professor) {
 		return Lecture.builder()
 			.lectureNumber(lectureNumber)
 			.lectureRoom(lectureRoom)
@@ -149,6 +166,13 @@ class LectureServiceTest extends IntegrationTestSupport {
 			.subject(subject)
 			.professor(professor)
 			.build();
+	}
+
+	private Department saveDepartment(String departmentName) {
+		Department department = new Department(departmentName);
+		entityManager.persist(department);
+
+		return department;
 	}
 
 }

--- a/src/test/java/site/courseregistrationsystem/student/application/StudentServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/student/application/StudentServiceTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import jakarta.persistence.EntityManager;
 import site.courseregistrationsystem.IntegrationTestSupport;
 import site.courseregistrationsystem.department.Department;
-import site.courseregistrationsystem.department.infrastructure.DepartmentRepository;
 import site.courseregistrationsystem.exception.student.NonexistenceStudentException;
 import site.courseregistrationsystem.student.Grade;
 import site.courseregistrationsystem.student.Student;
@@ -25,7 +25,7 @@ class StudentServiceTest extends IntegrationTestSupport {
 	private StudentRepository studentRepository;
 
 	@Autowired
-	private DepartmentRepository departmentRepository;
+	private EntityManager entityManager;
 
 	@Autowired
 	private Aes256Manager aes256Manager;
@@ -37,7 +37,7 @@ class StudentServiceTest extends IntegrationTestSupport {
 		String STUDENT_ID = "201711282";
 		String NAME = "황현";
 		Grade grade = Grade.SENIOR;
-		Department department = departmentRepository.save(new Department("전기전자공학부"));
+		Department department = saveDepartment("전기전자공학부");
 
 		Student student = new Student(
 			aes256Manager.encrypt(STUDENT_ID),
@@ -67,6 +67,13 @@ class StudentServiceTest extends IntegrationTestSupport {
 		// when & then
 		assertThatThrownBy(() -> studentService.fetchStudentInformation(INVALID_STUDENT_PK))
 			.isInstanceOf(NonexistenceStudentException.class);
+	}
+
+	private Department saveDepartment(String departmentName) {
+		Department department = new Department(departmentName);
+		entityManager.persist(department);
+
+		return department;
 	}
 
 }


### PR DESCRIPTION
## Key Feature

 - 생성자를 Builder를 사용하여 정리합니다.
- 불필요한 JpaRepository를 제거하고 EntityManager를 사용하도록 변경합니다.
- 동적 쿼리를 JPQL 대신 Querydsl을 사용하도록 변경합니다.


