### PR TITLE
Feature: 현재 시간과 학기를 확인하는 API 구현

### DIFF
--- a/src/docs/asciidoc/api/clock.adoc
+++ b/src/docs/asciidoc/api/clock.adoc
@@ -38,3 +38,28 @@ include::{snippets}/server-remaining-time-fetch-success/http-request.adoc[]
 
 include::{snippets}/server-remaining-time-fetch-success/http-response.adoc[]
 include::{snippets}/server-remaining-time-fetch-success/response-fields.adoc[]
+
+[[current-year-and-semester-fetch-success]]
+=== 현재 년도와 학기 조회 : 성공
+
+==== HTTP Request
+
+include::{snippets}/current-year-and-semester-fetch-success/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/current-year-and-semester-fetch-success/http-response.adoc[]
+include::{snippets}/current-year-and-semester-fetch-success/response-fields.adoc[]
+
+[[current-year-and-semester-fetch-fail]]
+=== 현재 년도와 학기 조회 : 실패 - 등록 되지 않은 현재 시간 정보
+
+==== HTTP Request
+
+include::{snippets}/current-year-and-semester-fetch-fail/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/current-year-and-semester-fetch-fail/http-response.adoc[]
+include::{snippets}/current-year-and-semester-fetch-fail/response-fields.adoc[]
+

--- a/src/main/java/site/courseregistrationsystem/clock/Clock.java
+++ b/src/main/java/site/courseregistrationsystem/clock/Clock.java
@@ -1,0 +1,33 @@
+package site.courseregistrationsystem.clock;
+
+import static site.courseregistrationsystem.util.ProjectConstant.*;
+
+import java.time.Year;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.courseregistrationsystem.lecture.Semester;
+
+@RedisHash("currentClock")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Clock {
+
+	@Id
+	private String current = CLOCK_ID;
+
+	private int year;
+	private String semester;
+
+	@Builder
+	private Clock(Year year, Semester semester) {
+		this.year = year.getValue();
+		this.semester = semester.name();
+	}
+
+}

--- a/src/main/java/site/courseregistrationsystem/clock/application/ClockService.java
+++ b/src/main/java/site/courseregistrationsystem/clock/application/ClockService.java
@@ -1,0 +1,26 @@
+package site.courseregistrationsystem.clock.application;
+
+import static site.courseregistrationsystem.util.ProjectConstant.*;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import site.courseregistrationsystem.clock.Clock;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
+import site.courseregistrationsystem.clock.infrastructure.ClockStorage;
+import site.courseregistrationsystem.exception.clock.NonexistenceClockException;
+
+@Service
+@RequiredArgsConstructor
+public class ClockService {
+
+	private final ClockStorage clockStorage;
+
+	public CurrentYearAndSemester fetchCurrentClock() {
+		Clock currentClock = clockStorage.findById(CLOCK_ID)
+			.orElseThrow(NonexistenceClockException::new);
+
+		return new CurrentYearAndSemester(currentClock);
+	}
+
+}

--- a/src/main/java/site/courseregistrationsystem/clock/dto/CurrentYearAndSemester.java
+++ b/src/main/java/site/courseregistrationsystem/clock/dto/CurrentYearAndSemester.java
@@ -1,0 +1,28 @@
+package site.courseregistrationsystem.clock.dto;
+
+import java.time.Year;
+
+import lombok.Getter;
+import site.courseregistrationsystem.clock.Clock;
+import site.courseregistrationsystem.lecture.Semester;
+
+@Getter
+public class CurrentYearAndSemester {
+
+	private final int year;
+	private final String semester;
+
+	public CurrentYearAndSemester(Clock clock) {
+		this.year = clock.getYear();
+		this.semester = clock.getSemester();
+	}
+
+	public Year fetchIntYearToObject() {
+		return Year.of(year);
+	}
+
+	public Semester fetchStringSemesterToObject() {
+		return Semester.valueOf(semester);
+	}
+
+}

--- a/src/main/java/site/courseregistrationsystem/clock/infrastructure/ClockStorage.java
+++ b/src/main/java/site/courseregistrationsystem/clock/infrastructure/ClockStorage.java
@@ -1,0 +1,8 @@
+package site.courseregistrationsystem.clock.infrastructure;
+
+import org.springframework.data.repository.CrudRepository;
+
+import site.courseregistrationsystem.clock.Clock;
+
+public interface ClockStorage extends CrudRepository<Clock, String> {
+}

--- a/src/main/java/site/courseregistrationsystem/clock/presentation/ClockController.java
+++ b/src/main/java/site/courseregistrationsystem/clock/presentation/ClockController.java
@@ -5,14 +5,20 @@ import java.time.LocalDateTime;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.RequiredArgsConstructor;
+import site.courseregistrationsystem.clock.application.ClockService;
 import site.courseregistrationsystem.clock.dto.CurrentServerTime;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
 import site.courseregistrationsystem.clock.dto.SessionRemainingTime;
 import site.courseregistrationsystem.util.api.ApiResponse;
 import site.courseregistrationsystem.util.api.ResponseMessage;
 import site.courseregistrationsystem.util.resolver.SessionTime;
 
 @RestController
+@RequiredArgsConstructor
 public class ClockController {
+
+	private final ClockService clockService;
 
 	@GetMapping("/clock/server")
 	public ApiResponse<CurrentServerTime> checkCurrentServerTime() {
@@ -24,6 +30,13 @@ public class ClockController {
 	@GetMapping("/clock/session")
 	public ApiResponse<SessionRemainingTime> fetchSessionRemainingTime(@SessionTime Long sessionTime) {
 		return ApiResponse.ok(ResponseMessage.SESSION_REMAINING_TIME_FETCH_SUCCESS.getMessage(), new SessionRemainingTime(sessionTime));
+	}
+
+	@GetMapping("/clock/current-year-and-semester")
+	public ApiResponse<CurrentYearAndSemester> fetchCurrentYearAndSemester() {
+		CurrentYearAndSemester currentYearAndSemester = clockService.fetchCurrentClock();
+
+		return ApiResponse.ok(ResponseMessage.CURRENT_YEAR_AND_SEMESTER_FETCH_SUCCESS.getMessage(), currentYearAndSemester);
 	}
 
 }

--- a/src/main/java/site/courseregistrationsystem/exception/ErrorType.java
+++ b/src/main/java/site/courseregistrationsystem/exception/ErrorType.java
@@ -48,7 +48,10 @@ public enum ErrorType {
 	// Enrollment
 	ENROLLMENT_DUPLICATION(HttpStatus.BAD_REQUEST, "중복된 과목을 수강 신청할 수 없습니다"),
 	NONEXISTENT_ENROLLMENT(HttpStatus.BAD_REQUEST, "수강 신청 내역이 존재하지 않습니다"),
-	LECTURE_NOT_IN_CURRENT_SEMESTER(HttpStatus.BAD_REQUEST, "현재 학기에 개강하는 강의가 아닙니다");
+	LECTURE_NOT_IN_CURRENT_SEMESTER(HttpStatus.BAD_REQUEST, "현재 학기에 개강하는 강의가 아닙니다"),
+
+	// Clock
+	CLOCK_NONEXISTENT(HttpStatus.BAD_REQUEST, "등록된 현재 년도-학기 정보가 없습니다");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/site/courseregistrationsystem/exception/clock/NonexistenceClockException.java
+++ b/src/main/java/site/courseregistrationsystem/exception/clock/NonexistenceClockException.java
@@ -1,0 +1,12 @@
+package site.courseregistrationsystem.exception.clock;
+
+import site.courseregistrationsystem.exception.CustomException;
+import site.courseregistrationsystem.exception.ErrorType;
+
+public class NonexistenceClockException extends CustomException {
+
+	public NonexistenceClockException() {
+		super(ErrorType.CLOCK_NONEXISTENT);
+	}
+
+}

--- a/src/main/java/site/courseregistrationsystem/registration/BasketRegistrationPeriod.java
+++ b/src/main/java/site/courseregistrationsystem/registration/BasketRegistrationPeriod.java
@@ -19,6 +19,7 @@ public class BasketRegistrationPeriod {
 
 	@Id
 	private String targetGrade = Grade.COMMON.name();
+
 	private LocalDateTime startTime;
 	private LocalDateTime endTime;
 	private int year;

--- a/src/main/java/site/courseregistrationsystem/registration/BasketRegistrationPeriod.java
+++ b/src/main/java/site/courseregistrationsystem/registration/BasketRegistrationPeriod.java
@@ -9,7 +9,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import site.courseregistrationsystem.lecture.Semester;
 import site.courseregistrationsystem.student.Grade;
 
 @RedisHash("basketRegistrationPeriod")
@@ -22,19 +21,15 @@ public class BasketRegistrationPeriod {
 
 	private LocalDateTime startTime;
 	private LocalDateTime endTime;
-	private int year;
-	private String semester;
 
 	public boolean isWithinTimeRange(LocalDateTime now) {
 		return startTime.compareTo(now) <= 0 && now.compareTo(endTime) <= 0;
 	}
 
 	@Builder
-	private BasketRegistrationPeriod(LocalDateTime startTime, LocalDateTime endTime, Semester semester) {
+	private BasketRegistrationPeriod(LocalDateTime startTime, LocalDateTime endTime) {
 		this.startTime = startTime;
 		this.endTime = endTime;
-		this.year = startTime.getYear();
-		this.semester = semester.name();
 	}
 
 }

--- a/src/main/java/site/courseregistrationsystem/registration/EnrollmentRegistrationPeriod.java
+++ b/src/main/java/site/courseregistrationsystem/registration/EnrollmentRegistrationPeriod.java
@@ -9,7 +9,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import site.courseregistrationsystem.lecture.Semester;
 import site.courseregistrationsystem.student.Grade;
 
 @RedisHash("enrollmentRegistrationPeriod")
@@ -21,16 +20,12 @@ public class EnrollmentRegistrationPeriod {
 	private String targetGrade;
 	private LocalDateTime startTime;
 	private LocalDateTime endTime;
-	private int year;
-	private String semester;
 
 	@Builder
-	private EnrollmentRegistrationPeriod(Grade targetGrade, LocalDateTime startTime, LocalDateTime endTime, Semester semester) {
+	private EnrollmentRegistrationPeriod(Grade targetGrade, LocalDateTime startTime, LocalDateTime endTime) {
 		this.targetGrade = targetGrade.name();
 		this.startTime = startTime;
 		this.endTime = endTime;
-		this.year = startTime.getYear();
-		this.semester = semester.name();
 	}
 
 	public boolean isWithinTimeRange(LocalDateTime now) {

--- a/src/main/java/site/courseregistrationsystem/registration/application/BasketRegistrationPeriodService.java
+++ b/src/main/java/site/courseregistrationsystem/registration/application/BasketRegistrationPeriodService.java
@@ -6,11 +6,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.courseregistrationsystem.clock.application.ClockService;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
 import site.courseregistrationsystem.exception.registration_period.InvalidBasketTimeException;
 import site.courseregistrationsystem.exception.registration_period.NonexistenceBasketRegistrationPeriodException;
 import site.courseregistrationsystem.exception.registration_period.StartTimeAfterEndTimeException;
 import site.courseregistrationsystem.exception.registration_period.StartTimeBeforeCurrentTimeException;
-import site.courseregistrationsystem.lecture.Semester;
 import site.courseregistrationsystem.registration.BasketRegistrationPeriod;
 import site.courseregistrationsystem.registration.dto.RegistrationDate;
 import site.courseregistrationsystem.registration.infrastructure.BasketRegistrationPeriodStorage;
@@ -21,16 +22,17 @@ import site.courseregistrationsystem.student.Grade;
 @RequiredArgsConstructor
 public class BasketRegistrationPeriodService {
 
+	private final ClockService clockService;
+
 	private final BasketRegistrationPeriodStorage basketRegistrationPeriodStorage;
 
 	@Transactional
-	public void saveBasketRegistrationPeriod(LocalDateTime now, LocalDateTime startTime, LocalDateTime endTime, Semester semester) {
+	public void saveBasketRegistrationPeriod(LocalDateTime now, LocalDateTime startTime, LocalDateTime endTime) {
 		checkInvalidTime(now, startTime, endTime);
 
 		BasketRegistrationPeriod basketRegistrationPeriod = BasketRegistrationPeriod.builder()
 			.startTime(startTime)
 			.endTime(endTime)
-			.semester(semester)
 			.build();
 
 		basketRegistrationPeriodStorage.save(basketRegistrationPeriod);
@@ -44,10 +46,8 @@ public class BasketRegistrationPeriodService {
 			throw new InvalidBasketTimeException();
 		}
 
-		return new RegistrationDate(
-			registrationPeriod.getYear(),
-			registrationPeriod.getSemester()
-		);
+		CurrentYearAndSemester currentYearAndSemester = clockService.fetchCurrentClock();
+		return new RegistrationDate(currentYearAndSemester);
 	}
 
 	private void checkInvalidTime(LocalDateTime now, LocalDateTime startTime, LocalDateTime endTime) {

--- a/src/main/java/site/courseregistrationsystem/registration/application/EnrollmentRegistrationPeriodService.java
+++ b/src/main/java/site/courseregistrationsystem/registration/application/EnrollmentRegistrationPeriodService.java
@@ -6,12 +6,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.courseregistrationsystem.clock.application.ClockService;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
 import site.courseregistrationsystem.exception.registration_period.InvalidEnrollmentTimeException;
 import site.courseregistrationsystem.exception.registration_period.NonexistenceCommonEnrollmentRegistrationPeriodException;
 import site.courseregistrationsystem.exception.registration_period.NonexistenceEnrollmentRegistrationPeriodException;
 import site.courseregistrationsystem.exception.registration_period.StartTimeAfterEndTimeException;
 import site.courseregistrationsystem.exception.registration_period.StartTimeBeforeCurrentTimeException;
-import site.courseregistrationsystem.lecture.Semester;
 import site.courseregistrationsystem.registration.EnrollmentRegistrationPeriod;
 import site.courseregistrationsystem.registration.dto.RegistrationDate;
 import site.courseregistrationsystem.registration.infrastructure.EnrollmentRegistrationPeriodStorage;
@@ -22,20 +23,18 @@ import site.courseregistrationsystem.student.Grade;
 @RequiredArgsConstructor
 public class EnrollmentRegistrationPeriodService {
 
+	private final ClockService clockService;
+
 	private final EnrollmentRegistrationPeriodStorage enrollmentRegistrationPeriodStorage;
 
 	@Transactional
-	public void saveEnrollmentRegistrationPeriod(LocalDateTime now,
-		LocalDateTime startTime, LocalDateTime endTime,
-		Grade targetGrade, Semester semester) {
-
+	public void saveEnrollmentRegistrationPeriod(LocalDateTime now, LocalDateTime startTime, LocalDateTime endTime, Grade targetGrade) {
 		checkInvalidTime(now, startTime, endTime);
 
 		EnrollmentRegistrationPeriod enrollmentRegistrationPeriod = EnrollmentRegistrationPeriod.builder()
 			.targetGrade(targetGrade)
 			.startTime(startTime)
 			.endTime(endTime)
-			.semester(semester)
 			.build();
 
 		enrollmentRegistrationPeriodStorage.save(enrollmentRegistrationPeriod);
@@ -45,21 +44,16 @@ public class EnrollmentRegistrationPeriodService {
 		EnrollmentRegistrationPeriod registrationPeriodInGrade = enrollmentRegistrationPeriodStorage.findById(grade.name())
 			.orElseThrow(NonexistenceEnrollmentRegistrationPeriodException::new);
 
+		CurrentYearAndSemester currentYearAndSemester = clockService.fetchCurrentClock();
 		if (registrationPeriodInGrade.isWithinTimeRange(now)) {
-			return new RegistrationDate(
-				registrationPeriodInGrade.getYear(),
-				registrationPeriodInGrade.getSemester()
-			);
+			return new RegistrationDate(currentYearAndSemester);
 		}
 
 		EnrollmentRegistrationPeriod registrationPeriodInCommon = enrollmentRegistrationPeriodStorage.findById(Grade.COMMON.name())
 			.orElseThrow(NonexistenceCommonEnrollmentRegistrationPeriodException::new);
 
 		if (registrationPeriodInCommon.isWithinTimeRange(now)) {
-			return new RegistrationDate(
-				registrationPeriodInCommon.getYear(),
-				registrationPeriodInCommon.getSemester()
-			);
+			return new RegistrationDate(currentYearAndSemester);
 		}
 
 		throw new InvalidEnrollmentTimeException();

--- a/src/main/java/site/courseregistrationsystem/registration/dto/BasketRegistrationPeriodSaveForm.java
+++ b/src/main/java/site/courseregistrationsystem/registration/dto/BasketRegistrationPeriodSaveForm.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import site.courseregistrationsystem.lecture.Semester;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -14,6 +13,5 @@ public class BasketRegistrationPeriodSaveForm {
 
 	private LocalDateTime startTime;
 	private LocalDateTime endTime;
-	private Semester semester;
 
 }

--- a/src/main/java/site/courseregistrationsystem/registration/dto/EnrollmentRegistrationPeriodSaveForm.java
+++ b/src/main/java/site/courseregistrationsystem/registration/dto/EnrollmentRegistrationPeriodSaveForm.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import site.courseregistrationsystem.lecture.Semester;
 import site.courseregistrationsystem.student.Grade;
 
 @NoArgsConstructor
@@ -16,6 +15,5 @@ public class EnrollmentRegistrationPeriodSaveForm {
 	private Grade grade;
 	private LocalDateTime startTime;
 	private LocalDateTime endTime;
-	private Semester semester;
 
 }

--- a/src/main/java/site/courseregistrationsystem/registration/dto/RegistrationDate.java
+++ b/src/main/java/site/courseregistrationsystem/registration/dto/RegistrationDate.java
@@ -3,6 +3,7 @@ package site.courseregistrationsystem.registration.dto;
 import java.time.Year;
 
 import lombok.Getter;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
 import site.courseregistrationsystem.lecture.Semester;
 
 @Getter
@@ -11,9 +12,9 @@ public class RegistrationDate {
 	private final Year year;
 	private final Semester semester;
 
-	public RegistrationDate(int year, String semester) {
-		this.year = Year.of(year);
-		this.semester = Semester.valueOf(semester);
+	public RegistrationDate(CurrentYearAndSemester currentYearAndSemester) {
+		this.year = currentYearAndSemester.fetchIntYearToObject();
+		this.semester = currentYearAndSemester.fetchStringSemesterToObject();
 	}
 
 }

--- a/src/main/java/site/courseregistrationsystem/registration/presentation/RegistrationPeriodController.java
+++ b/src/main/java/site/courseregistrationsystem/registration/presentation/RegistrationPeriodController.java
@@ -26,8 +26,8 @@ public class RegistrationPeriodController {
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping("/registration-period/enrollments")
 	public ApiResponse<Void> saveEnrollmentRegistrationPeriod(@RequestBody EnrollmentRegistrationPeriodSaveForm saveForm) {
-		enrollmentRegistrationPeriodService.saveEnrollmentRegistrationPeriod(LocalDateTime.now(),
-			saveForm.getStartTime(), saveForm.getEndTime(), saveForm.getGrade(), saveForm.getSemester());
+		enrollmentRegistrationPeriodService.saveEnrollmentRegistrationPeriod(LocalDateTime.now(), saveForm.getStartTime(), saveForm.getEndTime(),
+			saveForm.getGrade());
 
 		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.ENROLLMENT_REGISTRATION_PERIOD_SAVE_SUCCESS.getMessage(), null);
 	}
@@ -35,8 +35,7 @@ public class RegistrationPeriodController {
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping("/registration-period/baskets")
 	public ApiResponse<Void> saveBasketRegistrationPeriod(@RequestBody BasketRegistrationPeriodSaveForm saveForm) {
-		basketRegistrationPeriodService.saveBasketRegistrationPeriod(LocalDateTime.now(),
-			saveForm.getStartTime(), saveForm.getEndTime(), saveForm.getSemester());
+		basketRegistrationPeriodService.saveBasketRegistrationPeriod(LocalDateTime.now(), saveForm.getStartTime(), saveForm.getEndTime());
 
 		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.BASKET_REGISTRATION_PERIOD_SAVE_SUCCESS.getMessage(), null);
 	}

--- a/src/main/java/site/courseregistrationsystem/util/ProjectConstant.java
+++ b/src/main/java/site/courseregistrationsystem/util/ProjectConstant.java
@@ -6,5 +6,6 @@ public abstract class ProjectConstant {
 	public static final String SESSION_ID = "SESSIONID";
 	public static final String SESSION_TIME = "sessionTime";
 	public static final int DEFAULT_CREDIT_LIMIT = 18;
+	public static final String CLOCK_ID = "currentClock";
 
 }

--- a/src/main/java/site/courseregistrationsystem/util/api/ResponseMessage.java
+++ b/src/main/java/site/courseregistrationsystem/util/api/ResponseMessage.java
@@ -14,6 +14,7 @@ public enum ResponseMessage {
 
 	// Clock
 	CURRENT_SERVER_TIME_FETCH_SUCCESS("현재 서버 시간 조회에 성공했습니다"),
+	CURRENT_YEAR_AND_SEMESTER_FETCH_SUCCESS("현재 년도와 학기 조회에 성공했습니다"),
 
 	// Session
 	SESSION_RENEW_SUCCESS("세션 지속시간 갱신에 성공했습니다"),

--- a/src/test/java/site/courseregistrationsystem/RestDocsSupport.java
+++ b/src/test/java/site/courseregistrationsystem/RestDocsSupport.java
@@ -18,6 +18,7 @@ import site.courseregistrationsystem.auth.presentation.AuthController;
 import site.courseregistrationsystem.auth.presentation.CookieProperties;
 import site.courseregistrationsystem.basket.application.BasketService;
 import site.courseregistrationsystem.basket.presentation.BasketController;
+import site.courseregistrationsystem.clock.application.ClockService;
 import site.courseregistrationsystem.clock.presentation.ClockController;
 import site.courseregistrationsystem.enrollment.application.EnrollmentService;
 import site.courseregistrationsystem.enrollment.presentation.EnrollmentController;
@@ -78,6 +79,9 @@ public abstract class RestDocsSupport {
 
 	@MockBean
 	protected BasketRegistrationPeriodService basketRegistrationPeriodService;
+
+	@MockBean
+	protected ClockService clockService;
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/site/courseregistrationsystem/basket/application/BasketServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/basket/application/BasketServiceTest.java
@@ -21,6 +21,8 @@ import site.courseregistrationsystem.basket.Basket;
 import site.courseregistrationsystem.basket.dto.BasketDetail;
 import site.courseregistrationsystem.basket.dto.BasketList;
 import site.courseregistrationsystem.basket.infrastructure.BasketRepository;
+import site.courseregistrationsystem.clock.Clock;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
 import site.courseregistrationsystem.exception.basket.DuplicateBasketException;
 import site.courseregistrationsystem.exception.basket.NonexistenceBasketException;
 import site.courseregistrationsystem.exception.credit.CreditLimitExceededException;
@@ -76,7 +78,7 @@ class BasketServiceTest extends IntegrationTestSupport {
 		Year YEAR = Year.of(2024);
 		Semester SEMESTER = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(YEAR.getValue(), SEMESTER.name());
+		RegistrationDate registrationDate = createRegistrationDate(YEAR, SEMESTER);
 		BDDMockito.doReturn(registrationDate)
 			.when(basketRegistrationPeriodService)
 			.validateBasketRegistrationPeriod(any());
@@ -108,7 +110,7 @@ class BasketServiceTest extends IntegrationTestSupport {
 		Year YEAR = Year.of(2024);
 		Semester SEMESTER = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(YEAR.getValue(), SEMESTER.name());
+		RegistrationDate registrationDate = createRegistrationDate(YEAR, SEMESTER);
 		BDDMockito.doReturn(registrationDate)
 			.when(basketRegistrationPeriodService)
 			.validateBasketRegistrationPeriod(any());
@@ -134,7 +136,7 @@ class BasketServiceTest extends IntegrationTestSupport {
 		Year YEAR = Year.of(2024);
 		Semester SEMESTER = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(YEAR.getValue(), SEMESTER.name());
+		RegistrationDate registrationDate = createRegistrationDate(YEAR, SEMESTER);
 		BDDMockito.doReturn(registrationDate)
 			.when(basketRegistrationPeriodService)
 			.validateBasketRegistrationPeriod(any());
@@ -162,7 +164,7 @@ class BasketServiceTest extends IntegrationTestSupport {
 		Year YEAR = Year.of(2024);
 		Semester SEMESTER = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(YEAR.getValue(), SEMESTER.name());
+		RegistrationDate registrationDate = createRegistrationDate(YEAR, SEMESTER);
 		BDDMockito.doReturn(registrationDate)
 			.when(basketRegistrationPeriodService)
 			.validateBasketRegistrationPeriod(any());
@@ -193,7 +195,7 @@ class BasketServiceTest extends IntegrationTestSupport {
 		Year YEAR = Year.of(2024);
 		Semester SEMESTER = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(YEAR.getValue(), SEMESTER.name());
+		RegistrationDate registrationDate = createRegistrationDate(YEAR, SEMESTER);
 		BDDMockito.doReturn(registrationDate)
 			.when(basketRegistrationPeriodService)
 			.validateBasketRegistrationPeriod(any());
@@ -229,7 +231,7 @@ class BasketServiceTest extends IntegrationTestSupport {
 		Year YEAR = Year.of(2024);
 		Semester SEMESTER = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(YEAR.getValue(), SEMESTER.name());
+		RegistrationDate registrationDate = createRegistrationDate(YEAR, SEMESTER);
 		BDDMockito.doReturn(registrationDate)
 			.when(basketRegistrationPeriodService)
 			.validateBasketRegistrationPeriod(any());
@@ -365,7 +367,7 @@ class BasketServiceTest extends IntegrationTestSupport {
 
 		Lecture lecture = lectureRepository.save(createLecture(subject, YEAR, SEMESTER));
 
-		RegistrationDate registrationDate = new RegistrationDate(year, semester);
+		RegistrationDate registrationDate = createRegistrationDate(Year.of(year), Semester.valueOf(semester));
 		BDDMockito.doReturn(registrationDate)
 			.when(basketRegistrationPeriodService)
 			.validateBasketRegistrationPeriod(any());
@@ -452,6 +454,15 @@ class BasketServiceTest extends IntegrationTestSupport {
 			.student(student)
 			.lecture(lecture)
 			.build();
+	}
+
+	private static RegistrationDate createRegistrationDate(Year year, Semester semester) {
+		Clock clock = Clock.builder()
+			.year(year)
+			.semester(semester)
+			.build();
+		CurrentYearAndSemester currentYearAndSemester = new CurrentYearAndSemester(clock);
+		return new RegistrationDate(currentYearAndSemester);
 	}
 
 }

--- a/src/test/java/site/courseregistrationsystem/clock/application/ClockServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/clock/application/ClockServiceTest.java
@@ -1,0 +1,62 @@
+package site.courseregistrationsystem.clock.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Year;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import site.courseregistrationsystem.IntegrationTestSupport;
+import site.courseregistrationsystem.clock.Clock;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
+import site.courseregistrationsystem.clock.infrastructure.ClockStorage;
+import site.courseregistrationsystem.exception.clock.NonexistenceClockException;
+import site.courseregistrationsystem.lecture.Semester;
+
+class ClockServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private ClockStorage clockStorage;
+
+	@Autowired
+	private ClockService clockService;
+
+	@AfterEach
+	void clear() {
+		clockStorage.deleteAll();
+	}
+
+	@Test
+	@DisplayName("현재 년도와 학기 정보를 조회한다.")
+	void fetchCurrentYearAndSemester() throws Exception {
+		// given
+		Year YEAR = Year.of(2024);
+		Semester SEMESTER = Semester.FIRST;
+
+		Clock clock = Clock.builder()
+			.year(YEAR)
+			.semester(SEMESTER)
+			.build();
+
+		clockStorage.save(clock);
+
+		// when
+		CurrentYearAndSemester currentYearAndSemester = clockService.fetchCurrentClock();
+
+		// then
+		assertThat(currentYearAndSemester.getYear()).isEqualTo(YEAR.getValue());
+		assertThat(currentYearAndSemester.getSemester()).isEqualTo(SEMESTER.name());
+	}
+
+	@Test
+	@DisplayName("저장된 현재 시간 정보가 없다면 예외가 발생한다.")
+	void nonexistenceClock() throws Exception {
+		// when & then
+		assertThatThrownBy(() -> clockService.fetchCurrentClock())
+			.isInstanceOf(NonexistenceClockException.class);
+	}
+
+}

--- a/src/test/java/site/courseregistrationsystem/clock/presentation/ClockControllerTest.java
+++ b/src/test/java/site/courseregistrationsystem/clock/presentation/ClockControllerTest.java
@@ -1,5 +1,6 @@
 package site.courseregistrationsystem.clock.presentation;
 
+import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -7,12 +8,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.Year;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import jakarta.servlet.http.Cookie;
 import site.courseregistrationsystem.RestDocsSupport;
+import site.courseregistrationsystem.clock.Clock;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
+import site.courseregistrationsystem.exception.clock.NonexistenceClockException;
+import site.courseregistrationsystem.lecture.Semester;
 
 class ClockControllerTest extends RestDocsSupport {
 
@@ -83,6 +90,72 @@ class ClockControllerTest extends RestDocsSupport {
 					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
 					fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
 					fieldWithPath("data.sessionRemainingTime").type(JsonFieldType.NUMBER).description("남은 세션 시간")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("현재 년도와 학기 조회 : 성공")
+	void fetchCurrentYearAndSemester() throws Exception {
+		// given
+		String COOKIE_NAME = "SESSIONID";
+		String COOKIE_VALUE = "03166dc4-2c82-4e55-85f5-f47919f367a6";
+		Cookie sessionCookie = new Cookie(COOKIE_NAME, COOKIE_VALUE);
+
+		Clock clock = Clock.builder()
+			.year(Year.of(2024))
+			.semester(Semester.FIRST)
+			.build();
+		CurrentYearAndSemester currentYearAndSemester = new CurrentYearAndSemester(clock);
+
+		given(clockService.fetchCurrentClock())
+			.willReturn(currentYearAndSemester);
+
+		// when & then
+		mockMvc.perform(get("/clock/current-year-and-semester")
+				.cookie(sessionCookie))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.year").value(clock.getYear()))
+			.andExpect(jsonPath("$.data.semester").value(clock.getSemester()))
+			.andDo(document("current-year-and-semester-fetch-success",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+					fieldWithPath("data.year").type(JsonFieldType.NUMBER).description("현재 년도"),
+					fieldWithPath("data.semester").type(JsonFieldType.STRING).description("현재 학기")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("현재 년도와 학기 조회 : 실패 - 등록 되지 않은 현재 시간 정보")
+	void nonexistenceCurrentYearAndSemester() throws Exception {
+		// given
+		String COOKIE_NAME = "SESSIONID";
+		String COOKIE_VALUE = "03166dc4-2c82-4e55-85f5-f47919f367a6";
+		Cookie sessionCookie = new Cookie(COOKIE_NAME, COOKIE_VALUE);
+
+		given(clockService.fetchCurrentClock())
+			.willThrow(new NonexistenceClockException());
+
+		// when & then
+		mockMvc.perform(get("/clock/current-year-and-semester")
+				.cookie(sessionCookie))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andDo(document("current-year-and-semester-fetch-fail",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				responseFields(
+					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+					fieldWithPath("status").type(JsonFieldType.STRING).description("상태"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("메시지"),
+					fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터")
 				)
 			));
 	}

--- a/src/test/java/site/courseregistrationsystem/enrollment/application/EnrollmentServiceTest.java
+++ b/src/test/java/site/courseregistrationsystem/enrollment/application/EnrollmentServiceTest.java
@@ -24,6 +24,8 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import jakarta.persistence.EntityManager;
 import site.courseregistrationsystem.IntegrationTestSupport;
+import site.courseregistrationsystem.clock.Clock;
+import site.courseregistrationsystem.clock.dto.CurrentYearAndSemester;
 import site.courseregistrationsystem.department.Department;
 import site.courseregistrationsystem.enrollment.Enrollment;
 import site.courseregistrationsystem.enrollment.dto.EnrolledLecture;
@@ -83,7 +85,7 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 		Lecture lecture = saveLecture(department, subject, openingYear, semester);
 		saveSchedule(lecture, DayOfWeek.MON, Period.ONE, Period.THREE);
 
-		RegistrationDate registrationDate = new RegistrationDate(openingYear.getValue(), semester.name());
+		RegistrationDate registrationDate = createRegistrationDate(openingYear, semester);
 		BDDMockito.doReturn(registrationDate)
 			.when(enrollmentRegistrationPeriodService)
 			.validateEnrollmentRegistrationPeriod(any(), any());
@@ -109,7 +111,7 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 		Lecture lecture = saveLecture(department, subject, openingYear, semester);
 		saveSchedule(lecture, DayOfWeek.MON, Period.ONE, Period.THREE);
 
-		RegistrationDate registrationDate = new RegistrationDate(openingYear.getValue(), semester.name());
+		RegistrationDate registrationDate = createRegistrationDate(openingYear, semester);
 		BDDMockito.doReturn(registrationDate)
 			.when(enrollmentRegistrationPeriodService)
 			.validateEnrollmentRegistrationPeriod(any(), any());
@@ -132,7 +134,7 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 		Lecture pastLecture = saveLecture(department, subject1, Year.of(2023), Semester.FIRST);
 		saveSchedule(pastLecture, DayOfWeek.MON, Period.ONE, Period.THREE);  // 작년 강의 개설
 
-		RegistrationDate registrationDate = new RegistrationDate(2024, "FIRST");
+		RegistrationDate registrationDate = createRegistrationDate(Year.of(2024), Semester.FIRST);
 		BDDMockito.doReturn(registrationDate)
 			.when(enrollmentRegistrationPeriodService)
 			.validateEnrollmentRegistrationPeriod(any(), any());
@@ -154,7 +156,7 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 		Lecture pastLecture = saveLecture(department, subject1, Year.of(2024), Semester.FIRST);
 		saveSchedule(pastLecture, DayOfWeek.MON, Period.ONE, Period.THREE);  // 지난 학기 강의 개설
 
-		RegistrationDate registrationDate = new RegistrationDate(2024, "SECOND");
+		RegistrationDate registrationDate = createRegistrationDate(Year.of(2024), Semester.SECOND);
 		BDDMockito.doReturn(registrationDate)
 			.when(enrollmentRegistrationPeriodService)
 			.validateEnrollmentRegistrationPeriod(any(), any());
@@ -198,7 +200,7 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 		Year openingYear = Year.of(2024);
 		Semester semester = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(openingYear.getValue(), semester.name());
+		RegistrationDate registrationDate = createRegistrationDate(openingYear, semester);
 		BDDMockito.doReturn(registrationDate)
 			.when(enrollmentRegistrationPeriodService)
 			.validateEnrollmentRegistrationPeriod(any(), any());
@@ -236,7 +238,7 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 		saveSchedule(lectureOnMonday, DayOfWeek.MON, Period.ONE, Period.THREE);
 		saveSchedule(LectureOnFriday, DayOfWeek.FRI, Period.ONE, Period.THREE);
 
-		RegistrationDate registrationDate = new RegistrationDate(openingYear.getValue(), semester.name());
+		RegistrationDate registrationDate = createRegistrationDate(openingYear, semester);
 		BDDMockito.doReturn(registrationDate)
 			.when(enrollmentRegistrationPeriodService)
 			.validateEnrollmentRegistrationPeriod(any(), any());
@@ -269,7 +271,7 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 		Year openingYear = Year.of(2024);
 		Semester semester = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(openingYear.getValue(), semester.name());
+		RegistrationDate registrationDate = createRegistrationDate(openingYear, semester);
 		BDDMockito.doReturn(registrationDate)
 			.when(enrollmentRegistrationPeriodService)
 			.validateEnrollmentRegistrationPeriod(any(), any());
@@ -299,7 +301,7 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 		Year openingYear = Year.of(2024);
 		Semester semester = Semester.FIRST;
 
-		RegistrationDate registrationDate = new RegistrationDate(openingYear.getValue(), semester.name());
+		RegistrationDate registrationDate = createRegistrationDate(openingYear, semester);
 		BDDMockito.doReturn(registrationDate)
 			.when(enrollmentRegistrationPeriodService)
 			.validateEnrollmentRegistrationPeriod(any(), any());
@@ -559,6 +561,15 @@ class EnrollmentServiceTest extends IntegrationTestSupport {
 			.lastPeriod(lastPeriod)
 			.build();
 		entityManager.persist(schedule);
+	}
+
+	private static RegistrationDate createRegistrationDate(Year year, Semester semester) {
+		Clock clock = Clock.builder()
+			.year(year)
+			.semester(semester)
+			.build();
+		CurrentYearAndSemester currentYearAndSemester = new CurrentYearAndSemester(clock);
+		return new RegistrationDate(currentYearAndSemester);
 	}
 
 }

--- a/src/test/java/site/courseregistrationsystem/registration/presentation/RegistrationPeriodControllerTest.java
+++ b/src/test/java/site/courseregistrationsystem/registration/presentation/RegistrationPeriodControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import site.courseregistrationsystem.RestDocsSupport;
 import site.courseregistrationsystem.exception.registration_period.StartTimeAfterEndTimeException;
 import site.courseregistrationsystem.exception.registration_period.StartTimeBeforeCurrentTimeException;
-import site.courseregistrationsystem.lecture.Semester;
 import site.courseregistrationsystem.registration.dto.BasketRegistrationPeriodSaveForm;
 import site.courseregistrationsystem.registration.dto.EnrollmentRegistrationPeriodSaveForm;
 import site.courseregistrationsystem.student.Grade;
@@ -33,7 +32,7 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 		LocalDateTime startTime = LocalDateTime.of(2024, 1, 17, 9, 30, 0);
 		LocalDateTime endTime = LocalDateTime.of(2024, 1, 17, 10, 0, 0);
 
-		EnrollmentRegistrationPeriodSaveForm saveForm = new EnrollmentRegistrationPeriodSaveForm(Grade.FRESHMAN, startTime, endTime, Semester.FIRST);
+		EnrollmentRegistrationPeriodSaveForm saveForm = new EnrollmentRegistrationPeriodSaveForm(Grade.FRESHMAN, startTime, endTime);
 
 		// when & then
 		mockMvc.perform(post("/registration-period/enrollments")
@@ -47,8 +46,7 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 				requestFields(
 					fieldWithPath("grade").type(JsonFieldType.STRING).description("타겟 학년"),
 					fieldWithPath("startTime").type(JsonFieldType.VARIES).description("시작 시간"),
-					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간"),
-					fieldWithPath("semester").type(JsonFieldType.STRING).description("학기")
+					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간")
 				),
 				responseFields(
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
@@ -64,12 +62,12 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 	void invalidTimeEnrollmentRegistrationPeriod() throws Exception {
 		// given
 		doThrow(new StartTimeBeforeCurrentTimeException()).when(enrollmentRegistrationPeriodService)
-			.saveEnrollmentRegistrationPeriod(any(), any(), any(), any(), any());
+			.saveEnrollmentRegistrationPeriod(any(), any(), any(), any());
 
 		LocalDateTime startTime = LocalDateTime.of(2024, 1, 17, 9, 30, 0);
 		LocalDateTime endTime = LocalDateTime.of(2024, 1, 17, 10, 0, 0);
 
-		EnrollmentRegistrationPeriodSaveForm saveForm = new EnrollmentRegistrationPeriodSaveForm(Grade.FRESHMAN, startTime, endTime, Semester.FIRST);
+		EnrollmentRegistrationPeriodSaveForm saveForm = new EnrollmentRegistrationPeriodSaveForm(Grade.FRESHMAN, startTime, endTime);
 
 		// when & then
 		mockMvc.perform(post("/registration-period/enrollments")
@@ -83,8 +81,7 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 				requestFields(
 					fieldWithPath("grade").type(JsonFieldType.STRING).description("타겟 학년"),
 					fieldWithPath("startTime").type(JsonFieldType.VARIES).description("시작 시간"),
-					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간"),
-					fieldWithPath("semester").type(JsonFieldType.STRING).description("학기")
+					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간")
 				),
 				responseFields(
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
@@ -100,12 +97,12 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 	void earlyEndTimeEnrollmentRegistrationPeriod() throws Exception {
 		// given
 		doThrow(new StartTimeAfterEndTimeException()).when(enrollmentRegistrationPeriodService)
-			.saveEnrollmentRegistrationPeriod(any(), any(), any(), any(), any());
+			.saveEnrollmentRegistrationPeriod(any(), any(), any(), any());
 
 		LocalDateTime startTime = LocalDateTime.of(2024, 1, 17, 9, 30, 0);
 		LocalDateTime endTime = LocalDateTime.of(2024, 1, 17, 10, 0, 0);
 
-		EnrollmentRegistrationPeriodSaveForm saveForm = new EnrollmentRegistrationPeriodSaveForm(Grade.FRESHMAN, startTime, endTime, Semester.FIRST);
+		EnrollmentRegistrationPeriodSaveForm saveForm = new EnrollmentRegistrationPeriodSaveForm(Grade.FRESHMAN, startTime, endTime);
 
 		// when & then
 		mockMvc.perform(post("/registration-period/enrollments")
@@ -119,8 +116,7 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 				requestFields(
 					fieldWithPath("grade").type(JsonFieldType.STRING).description("타겟 학년"),
 					fieldWithPath("startTime").type(JsonFieldType.VARIES).description("시작 시간"),
-					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간"),
-					fieldWithPath("semester").type(JsonFieldType.STRING).description("학기")
+					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간")
 				),
 				responseFields(
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
@@ -138,7 +134,7 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 		LocalDateTime startTime = LocalDateTime.of(2024, 1, 17, 9, 30, 0);
 		LocalDateTime endTime = LocalDateTime.of(2024, 1, 17, 10, 0, 0);
 
-		BasketRegistrationPeriodSaveForm saveForm = new BasketRegistrationPeriodSaveForm(startTime, endTime, Semester.FIRST);
+		BasketRegistrationPeriodSaveForm saveForm = new BasketRegistrationPeriodSaveForm(startTime, endTime);
 
 		// when & then
 		mockMvc.perform(post("/registration-period/baskets")
@@ -151,8 +147,7 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 				preprocessResponse(prettyPrint()),
 				requestFields(
 					fieldWithPath("startTime").type(JsonFieldType.VARIES).description("시작 시간"),
-					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간"),
-					fieldWithPath("semester").type(JsonFieldType.STRING).description("학기")
+					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간")
 				),
 				responseFields(
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
@@ -168,12 +163,12 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 	void invalidTimeBasketRegistrationPeriod() throws Exception {
 		// given
 		doThrow(new StartTimeBeforeCurrentTimeException()).when(basketRegistrationPeriodService)
-			.saveBasketRegistrationPeriod(any(), any(), any(), any());
+			.saveBasketRegistrationPeriod(any(), any(), any());
 
 		LocalDateTime startTime = LocalDateTime.of(2024, 1, 17, 9, 30, 0);
 		LocalDateTime endTime = LocalDateTime.of(2024, 1, 17, 10, 0, 0);
 
-		BasketRegistrationPeriodSaveForm saveForm = new BasketRegistrationPeriodSaveForm(startTime, endTime, Semester.FIRST);
+		BasketRegistrationPeriodSaveForm saveForm = new BasketRegistrationPeriodSaveForm(startTime, endTime);
 
 		// when & then
 		mockMvc.perform(post("/registration-period/baskets")
@@ -186,8 +181,7 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 				preprocessResponse(prettyPrint()),
 				requestFields(
 					fieldWithPath("startTime").type(JsonFieldType.VARIES).description("시작 시간"),
-					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간"),
-					fieldWithPath("semester").type(JsonFieldType.STRING).description("학기")
+					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간")
 				),
 				responseFields(
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
@@ -203,12 +197,12 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 	void earlyEndTimeBasketRegistrationPeriod() throws Exception {
 		// given
 		doThrow(new StartTimeAfterEndTimeException()).when(basketRegistrationPeriodService)
-			.saveBasketRegistrationPeriod(any(), any(), any(), any());
+			.saveBasketRegistrationPeriod(any(), any(), any());
 
 		LocalDateTime startTime = LocalDateTime.of(2024, 1, 17, 9, 30, 0);
 		LocalDateTime endTime = LocalDateTime.of(2024, 1, 17, 10, 0, 0);
 
-		BasketRegistrationPeriodSaveForm saveForm = new BasketRegistrationPeriodSaveForm(startTime, endTime, Semester.FIRST);
+		BasketRegistrationPeriodSaveForm saveForm = new BasketRegistrationPeriodSaveForm(startTime, endTime);
 
 		// when & then
 		mockMvc.perform(post("/registration-period/baskets")
@@ -221,8 +215,7 @@ class RegistrationPeriodControllerTest extends RestDocsSupport {
 				preprocessResponse(prettyPrint()),
 				requestFields(
 					fieldWithPath("startTime").type(JsonFieldType.VARIES).description("시작 시간"),
-					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간"),
-					fieldWithPath("semester").type(JsonFieldType.STRING).description("학기")
+					fieldWithPath("endTime").type(JsonFieldType.VARIES).description("종료 시간")
 				),
 				responseFields(
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),


### PR DESCRIPTION
## Key Feature

- 운영자는 현재 시간과 학기를 redis 에 저장한다. (실제 API 구현 없이 redis 에 직접 넣는다.)
- 학생은 수강 신청과 수강 바구니의 기간 검증을 성공하면, 현재 시간과 학기를 받아온다.    
- 학생은 현재 시간과 학기를 받아올 수 있다.

다음 3가지 기능을 구현하였습니다.

## To reviewer

기존의 수강 신청 기간 객체나 수강 바구니 신청 기간 객체가 year 와 semester 를 갖고 있었는데, 이를 제거하였습니다.

따라서 학생은 xx 신청 기간 검증을 성공하면 ClockStorage 에 저장된 현재 년도와 현재 학기 정보를 받아 year 와 semester 를 알 수 있습니다.

또한 GET /clock/current-year-and-semester  을 통해 현재 년도와 학기를 조회하는 API 요청도 할 수 있습니다.


